### PR TITLE
add option delete task

### DIFF
--- a/engine/SrvConsult.php
+++ b/engine/SrvConsult.php
@@ -102,7 +102,31 @@
 	}
 
 
+	function getTaskUserDelete($task_id) {
 
+		$checkTaskData = $this->daoQuery("SELECT * FROM tasks WHERE id = '".intval($task_id)."'");
+
+		ob_start(); 
+
+		//LO que he aprendido a hacer son borrados logicos no delete directos ya que puede utilizarse mas adelante la información o sirve de historico
+
+		$this->daoQuery("UPDATE tasks SET 
+			is_deleted = 1 
+			WHERE id = ".intval($task_id)."");
+
+		$checkUpdate = $this->daoQuery("SELECT COUNT(*) c FROM tasks WHERE id = ".intval($task_id)."");
+
+		ob_clean(); 
+
+		header('Content-Type: application/json');
+
+		if ($checkUpdate[0]['c'] == "1") {
+			echo json_encode(['success' => true]);
+		} else {
+			echo json_encode(['success' => false]);
+		}
+		return;
+	}
 
 
 	}

--- a/engine/frontConsult.php
+++ b/engine/frontConsult.php
@@ -20,5 +20,8 @@
 		$inst->getTaskUserUpdate($_POST['task_id'],$_POST['task_name'], $_POST['task_description'], $_POST['task_status'] );
 	}
 
+	if (isset($_POST['getTaskUserDelete'])) {
+		$inst->getTaskUserDelete($_POST['task_id']);
+	}
 
 ?>

--- a/js/gestTask.js
+++ b/js/gestTask.js
@@ -32,6 +32,7 @@ $(document).ready(function () {
                                  status+
                                  '<div class="flex justify-end space-x-2 mt-4">'+
                                  '<button class="text-blue-500 hover:text-blue-700 edit-task" data-id="'+data[i]['id']+'"><i class="fas fa-edit"></i> Editar</button>'+
+                                 '<button class="text-red-500 hover:text-red-700 delete-task" data-id="'+data[i]['id']+'"><i class="fas fa-trash"></i> Eliminar</button>'+
                                  '</div>'+
                                  '</div>';
                 }
@@ -155,6 +156,35 @@ $(document).ready(function () {
             },
             error: function(xhr, status, error) {
                 console.log("Error: " + error);  
+            }
+        });
+    });
+
+    $(document).on('click', '.delete-task', function() {
+        var taskId = $(this).data('id');  
+
+        Swal.fire({
+            title: '¿Estás seguro?',
+            text: "No podrás revertir esta acción",
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonText: 'Sí, eliminar',
+            cancelButtonText: 'Cancelar'
+        }).then((result) => {
+            if (result.isConfirmed) {
+                $.ajax({
+                    url: '../engine/frontConsult.php',  
+                    type: 'POST',
+                    data: {  getTaskUserDelete: true,task_id: taskId },
+                    success: function(response) {
+                        if (response.success) {
+                            Swal.fire('¡Eliminado!', 'La tarea ha sido eliminada.', 'success');
+                            chargeTaskUser();  
+                        } else {
+                            Swal.fire('Error', 'Hubo un error al eliminar la tarea.', 'error');
+                        }
+                    }
+                });
             }
         });
     });


### PR DESCRIPTION
Logic is created to delete the user's task. While the action is "delete," a logical deletion is performed — the record remains in the database but with a status of 1.

![image](https://github.com/user-attachments/assets/cdb8fa86-43a3-49d2-999f-e0ba9ec1f426)

![image](https://github.com/user-attachments/assets/6da9eaa0-5b96-465c-95dc-3d76e1e4c866)

![image](https://github.com/user-attachments/assets/6d5ffb2f-7e4e-47fa-9bde-3cc046f56004)

![image](https://github.com/user-attachments/assets/8964f08f-5424-410c-b185-9a57d3b7f142)

![image](https://github.com/user-attachments/assets/bf786551-b379-4474-a3e5-8c65e240abaa)



